### PR TITLE
Support configuration directories and config_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ def create_pipelines(config: dict[str, Any] | None = None) -> dict[str, Pipeline
 
 
 if __name__ == "__main__":
-    # Relative config file paths allow for searching based on cwd, git root, or parent directories
-    composer = HamiltonComposer(create_pipelines, config_file="config.yaml", schema=AppConfig)
+    # Relative config paths allow for searching based on cwd, git root, or parent directories
+    composer = HamiltonComposer(create_pipelines, config_path="config.yaml", schema=AppConfig)
     cli = build_cli("advanced-processor", composer)
     cli()
 
@@ -237,7 +237,7 @@ Run with configuration:
 ```bash
 python advanced_app.py run analyze raw_text="Hello beautiful world"
 python advanced_app.py run analyze raw_text="Hello world" preprocessing.uppercase=false
-python advanced_app.py shell --config-file custom_config.yaml
+python advanced_app.py shell --config-path custom_config.yaml
 ```
 
 ## Using the CLI
@@ -261,8 +261,8 @@ python my_app.py run <pipeline_name>
 # With configuration overrides using a OmegaConf dotlist
 python my_app.py run <pipeline_name> <input_param1>=<value1> <input_param2>=<value2>
 
-# With custom config file
-python my_app.py --config-file run <pipeline_name> custom.yaml <input_param>=<value>
+# With custom config path
+python my_app.py --config-path run <pipeline_name> custom.yaml <input_param>=<value>
 ```
 
 Examples:
@@ -286,9 +286,9 @@ This launches an IPython shell with:
 
 Global options available for all commands:
 
-- `--config-file, -c`: Specify a custom configuration file. If a relative path is given, it will searched for based on the current working directory and search options.
-- `--search-git-root, -g`: Search for config files from git root. Only applies if `--config-file` is a relative path.
-- `--search-recursive, -r`: Search for config files recursively in parent directories. only applies if `--config-file` is a relative path.
+- `--config-path, -c`: Specify a custom configuration file or directory. If a relative path is given, it will searched for based on the current working directory and search options.
+- `--search-git-root, -g`: Search for config files from git root. Only applies if `--config-path` is a relative path.
+- `--search-recursive, -r`: Search for config files recursively in parent directories. only applies if `--config-path` is a relative path.
 - `--debug, -d`: Enable debug mode with detailed logging
 - `--help, -h`: Show help information
 
@@ -363,7 +363,7 @@ Use your pipelines directly in Jupyter notebooks:
 from my_app import create_pipelines
 from hamilton_composer import HamiltonComposer
 
-composer = HamiltonComposer(create_pipelines, config_file="config.yaml")
+composer = HamiltonComposer(create_pipelines, config_path="config.yaml")
 pipelines = composer.get_pipelines()
 
 # Execute pipeline
@@ -383,7 +383,7 @@ Hamilton Composer uses [OmegaConf](https://omegaconf.readthedocs.io/) for config
 ```python
 composer = HamiltonComposer(
     create_pipelines,
-    config_file="config.yaml",  # Path to config file
+    config_path="config.yaml",  # Path to config file or directory
     schema=MyConfigSchema       # Optional validation schema
 )
 
@@ -416,7 +416,7 @@ class AppConfig:
 
 composer = HamiltonComposer(
     create_pipelines,
-    config_file="config.yaml",
+    config_path="config.yaml",
     schema=AppConfig
 )
 ```

--- a/src/hamilton_composer/cli/context.py
+++ b/src/hamilton_composer/cli/context.py
@@ -19,14 +19,14 @@ class AppContext:
         composer: HamiltonComposer,
         logger: Logger,
         *,
-        config_file: str | Path | None = None,
+        config_path: str | Path | None = None,
         search_recursive: bool = False,
         search_git_root: bool = False,
     ) -> None:
         self._project_name = name
         self._composer = composer
         self._logger = logger
-        self._config_file = config_file
+        self._config_path = config_path
         self._search_recursive = search_recursive
         self._search_git_root = search_git_root
         self._cached_pipelines: dict[str, Pipeline] | None = None
@@ -46,7 +46,7 @@ class AppContext:
         """Delegates config loading to the current Hamilton composer within the current context."""
         if self._cached_config is None:
             self._cached_config = self._composer.load_config(
-                filepath=self._config_file,
+                path=self._config_path,
                 params=params,
                 search_git_root=self._search_git_root,
                 search_recursive=self._search_recursive,

--- a/src/hamilton_composer/cli/factory.py
+++ b/src/hamilton_composer/cli/factory.py
@@ -72,7 +72,7 @@ def build_cli(
             name=project_name,
             composer=composer,
             logger=logger,
-            config_file=kwargs["config_file"],
+            config_path=kwargs["config_path"],
             search_git_root=kwargs["search_git_root"],
             search_recursive=kwargs["search_recursive"],
         )
@@ -94,8 +94,8 @@ def build_cli(
         is_flag=True,
         default=False,
         help=(
-            "Search for the configuration file recursively in parent directories. Only used if "
-            "`--config-file` is a relative path (either the specified or default value)."
+            "Search for the configuration path recursively in parent directories. Only used if "
+            "`--config-path` is a relative path (either the specified or default value)."
         ),
     )(app)
 
@@ -105,18 +105,19 @@ def build_cli(
         is_flag=True,
         default=False,
         help=(
-            "Search for the configuration directory relative to the git root. Only used if "
-            "`--config-file` is a relative path (either the specified or default value)."
+            "Search for the configuration path relative to the git root. Only used if "
+            "`--config-path` is a relative path (either the specified or default value)."
         ),
     )(app)
 
     app = click.option(
-        "--config-file",
-        default=composer.config_file,
+        "--config-path",
+        "-c",
+        default=composer.config_path,
         show_default=False,  # The default is set manually in the help
         help=(
-            f"Location of YAML configuration file for the project pipelines. "
-            f"[default: {composer.config_file}]"
+            "Location of configuration file or directory for the project pipelines. "
+            f"[default: {composer.config_path}]"
         ),
     )(app)
 

--- a/src/hamilton_composer/composer.py
+++ b/src/hamilton_composer/composer.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import fields
 from dataclasses import is_dataclass
 from pathlib import Path
@@ -14,6 +15,9 @@ else:
     PipelineFunction = object
 
 
+_MISSING = object()
+
+
 class HamiltonComposer:
     """
     A composer that supports managing Hamilton pipelines with optional OmegaConf configurations.
@@ -26,12 +30,12 @@ class HamiltonComposer:
             qualified name of a module and function. In either case, the function can optionally
             accept a single dictionary argument for configuration parameters and return a dictionary
             mapping pipeline names to their respective `Pipeline` instances.
-        config_file (str | pathlib.Path, optional):
-            Path to configuration YAML file. If the path is specified as an absolute path, it will
-            be used as is. If the path is specified as a relative path, it will be resolved from the
-            current working directory subject to the search options in `load_config`. If None, the
-            composer will create an empty configuration, note that overrides can still be used in
-            this case.
+        config_path (str | pathlib.Path, optional):
+            Path to configuration YAML file or directory. If the path is specified as an absolute
+            path, it will be used as is. If the path is specified as a relative path, it will be
+            resolved from the current working directory subject to the search options in
+            `load_config`. If None, the composer will create an empty configuration, note that
+            overrides can still be used in this case.
         schema (type, optional):
             Structured config schema (dataclass or attrs class) to validate/complete config. If
             not provided, no validation is performed. Must be either a dataclass either from the
@@ -42,8 +46,10 @@ class HamiltonComposer:
     def __init__(
         self,
         pipeline_function: PipelineFunction | str,
-        config_file: str | Path | None = None,
+        config_path: str | Path | None = None,
         schema: type | None = None,
+        *,
+        config_file: object = _MISSING,
     ) -> None:
         if not isinstance(pipeline_function, str) and not callable(pipeline_function):
             raise TypeError(
@@ -51,7 +57,20 @@ class HamiltonComposer:
                 "qualified name of a module and function."
             )
         self._pipeline_function = pipeline_function
-        self._config_file = config_file
+        if config_file is not _MISSING:
+            warnings.warn(
+                "The 'config_file' parameter is deprecated. Please use 'config_path' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if config_path is not None and config_path != config_file:
+                raise ValueError(
+                    "Both 'config_path' and the deprecated 'config_file' were provided. "
+                    "Please supply only 'config_path'."
+                )
+            config_path = cast(str | Path | None, config_file)
+
+        self._config_path = config_path
 
         self._schema = None
         if schema:
@@ -65,24 +84,38 @@ class HamiltonComposer:
             self._schema = schema
 
     @property
+    def config_path(self) -> Path | None:
+        """Returns the location of the configuration path (relative or absolute)."""
+        return Path(self._config_path) if self._config_path is not None else None
+
+    @property
     def config_file(self) -> Path | None:
-        """Returns the location of configuration file (relative or absolute)."""
-        return Path(self._config_file) if self._config_file is not None else None
+        """Deprecated alias for :attr:`config_path`."""
+
+        warnings.warn(
+            "'config_file' is deprecated and will be removed in a future release. "
+            "Use 'config_path' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.config_path
 
     def load_config(
         self,
-        filepath: str | Path | None = None,
+        path: str | Path | None = None,
         params: Iterable[str] | None = None,
         search_git_root: bool = False,
         search_recursive: bool = False,
+        *,
+        filepath: object = _MISSING,
     ) -> dict[str, Any]:
         """
         Loads the configuration for the composer using OmegaConf.
 
         Args:
-            filepath (str | Path, optional):
-                Override the path to the configuration file specified in `config_file` during
-                insanitation. If this is a relative path, it will be resolved against the current
+            path (str | Path, optional):
+                Override the path to the configuration specified in `config_path` during
+                initialization. If this is a relative path, it will be resolved against the current
                 working directory. If it is an absolute path, it will be used as is. If the path
                 does not exist, an error will be raised.
             params (Iterable[str], optional):
@@ -90,11 +123,11 @@ class HamiltonComposer:
                 key-value pairs in the form of `key=value`. If not provided, no additional
                 parameters will be used.
             search_git_root (bool, optional):
-                If True attempts to find the config directory relative to the git root. Defaults to
-                False. Ignored if `filepath` is an absolute path.
+                If True attempts to find the config path relative to the git root. Defaults to
+                False. Ignored if `path` is an absolute path.
             search_recursive (bool, optional):
-                If True, searches for the config directory recursively from the current working
-                directory. Defaults to False. Ignored if `filepath` is an absolute path.
+                If True, searches for the config path recursively from the current working
+                directory. Defaults to False. Ignored if `path` is an absolute path.
 
         Returns:
             The composed configuration as a dictionary or an instance of the current schema.
@@ -102,15 +135,27 @@ class HamiltonComposer:
         """
         from omegaconf import OmegaConf
 
-        config_file = self._resolve_config_file(
-            filepath if filepath is not None else self._config_file,
+        if filepath is not _MISSING:
+            warnings.warn(
+                "The 'filepath' argument is deprecated. Please use 'path' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if path is not None and path != filepath:
+                raise ValueError(
+                    "Both 'path' and the deprecated 'filepath' were provided. Please supply only 'path'."
+                )
+            path = cast(str | Path | None, filepath)
+
+        config_path = self._resolve_config_path(
+            path if path is not None else self._config_path,
             search_git_root=search_git_root,
             search_recursive=search_recursive,
         )
 
         params = OmegaConf.from_dotlist(list(params)) if params else OmegaConf.create()
 
-        composed = OmegaConf.load(config_file) if config_file else OmegaConf.create()
+        composed = self._load_config_from_path(config_path)
         composed = OmegaConf.merge(composed, params)
 
         if self._schema:
@@ -159,13 +204,13 @@ class HamiltonComposer:
 
         return create_pipelines_func(config)
 
-    def _resolve_config_file(
+    def _resolve_config_path(
         self,
         initial_path: str | Path | None,
         search_git_root: bool,
         search_recursive: bool,
     ) -> Path | None:
-        """Resolves the location of the configuration file to an absolute path."""
+        """Resolves the location of the configuration path to an absolute path."""
         if initial_path is None:
             return None
 
@@ -173,7 +218,7 @@ class HamiltonComposer:
 
         if path.is_absolute():
             if not path.exists():
-                raise FileNotFoundError(f"Configuration directory '{path}' does not exist.")
+                raise FileNotFoundError(f"Configuration path '{path}' does not exist.")
             return path.resolve()
 
         local_path = Path.cwd().joinpath(path)
@@ -196,6 +241,66 @@ class HamiltonComposer:
                 current_dir = current_dir.parent
 
         raise FileNotFoundError(
-            f"Configuration directory '{path}' not found in the current working directory or "
-            f"git root. Consider using an absolute path."
+            f"Configuration path '{path}' not found in the current working directory or git root. "
+            f"Consider using an absolute path."
         )
+
+    def _load_config_from_path(self, path: Path | None):
+        """Load a configuration from a file or directory."""
+
+        from omegaconf import OmegaConf
+        from omegaconf.errors import OmegaConfBaseException
+
+        if path is None:
+            return OmegaConf.create()
+
+        if path.is_dir():
+            config_data: dict[str, Any] = {}
+            for child in sorted(path.iterdir(), key=lambda item: item.name):
+                if child.is_dir():
+                    key = child.name
+                    if key in config_data:
+                        raise ValueError(
+                            f"Duplicate configuration key '{key}' found while loading '{path}'."
+                        )
+                    nested = self._load_config_from_path(child)
+                    config_data[key] = OmegaConf.to_container(nested, resolve=False)
+                    continue
+
+                if child.is_file():
+                    key = child.stem
+                    if key in config_data:
+                        raise ValueError(
+                            f"Duplicate configuration key '{key}' found while loading '{path}'."
+                        )
+                    try:
+                        loaded = OmegaConf.load(child)
+                    except (OSError, OmegaConfBaseException) as exc:
+                        if isinstance(exc, OSError) and "Invalid loaded object type" in str(exc):
+                            import yaml
+
+                            with child.open("r", encoding="utf-8") as stream:
+                                config_data[key] = yaml.safe_load(stream)
+                            continue
+                        raise ValueError(f"Failed to load configuration file '{child}'.") from exc
+                    container = OmegaConf.to_container(loaded, resolve=False)
+                    if isinstance(container, dict) and len(container) == 1:
+                        sole_value = next(iter(container.values()))
+                        if sole_value is None:
+                            import yaml
+
+                            with child.open("r", encoding="utf-8") as stream:
+                                yaml_value = yaml.safe_load(stream)
+                            if not isinstance(yaml_value, (dict, list)):
+                                config_data[key] = yaml_value
+                                continue
+                    config_data[key] = container
+            return OmegaConf.create(config_data)
+
+        if path.is_file():
+            try:
+                return OmegaConf.load(path)
+            except (OSError, OmegaConfBaseException) as exc:
+                raise ValueError(f"Failed to load configuration file '{path}'.") from exc
+
+        raise FileNotFoundError(f"Configuration path '{path}' does not exist.")

--- a/src/hamilton_composer/composer.py
+++ b/src/hamilton_composer/composer.py
@@ -88,26 +88,12 @@ class HamiltonComposer:
         """Returns the location of the configuration path (relative or absolute)."""
         return Path(self._config_path) if self._config_path is not None else None
 
-    @property
-    def config_file(self) -> Path | None:
-        """Deprecated alias for :attr:`config_path`."""
-
-        warnings.warn(
-            "'config_file' is deprecated and will be removed in a future release. "
-            "Use 'config_path' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.config_path
-
     def load_config(
         self,
         path: str | Path | None = None,
         params: Iterable[str] | None = None,
         search_git_root: bool = False,
         search_recursive: bool = False,
-        *,
-        filepath: object = _MISSING,
     ) -> dict[str, Any]:
         """
         Loads the configuration for the composer using OmegaConf.
@@ -134,18 +120,6 @@ class HamiltonComposer:
 
         """
         from omegaconf import OmegaConf
-
-        if filepath is not _MISSING:
-            warnings.warn(
-                "The 'filepath' argument is deprecated. Please use 'path' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if path is not None and path != filepath:
-                raise ValueError(
-                    "Both 'path' and the deprecated 'filepath' were provided. Please supply only 'path'."
-                )
-            path = cast(str | Path | None, filepath)
 
         config_path = self._resolve_config_path(
             path if path is not None else self._config_path,
@@ -247,7 +221,6 @@ class HamiltonComposer:
 
     def _load_config_from_path(self, path: Path | None):
         """Load a configuration from a file or directory."""
-
         from omegaconf import OmegaConf
         from omegaconf.errors import OmegaConfBaseException
 

--- a/tests/api/test_execution.py
+++ b/tests/api/test_execution.py
@@ -1,5 +1,4 @@
 import os
-import os
 from dataclasses import dataclass
 
 from hamilton_composer import HamiltonComposer

--- a/tests/api/test_execution.py
+++ b/tests/api/test_execution.py
@@ -1,4 +1,5 @@
 import os
+import os
 from dataclasses import dataclass
 
 from hamilton_composer import HamiltonComposer
@@ -39,14 +40,30 @@ class TestPipelineExecutionWithoutConfig:
 class TestPipelineExecutionWithConfig:
     """Test pipeline execution with configuration files."""
 
-    def test_execution_with_config_file(self, tmp_path):
+    def test_execution_with_config_path(self, tmp_path):
         """Test pipeline execution with YAML config file."""
         os.chdir(tmp_path)
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("numbers: [1, 2, 3]")
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("numbers: [1, 2, 3]")
 
         composer = HamiltonComposer(
-            "tests.defs.pipelines.create_pipelines", config_file=config_file
+            "tests.defs.pipelines.create_pipelines", config_path=config_path
+        )
+        config = composer.load_config()
+        pipelines = composer.find_pipelines(config)
+        result = pipelines["simple_pipeline"].execute(inputs=config)
+        assert result == {"sum_doubled": 12}
+
+    def test_execution_with_config_directory(self, tmp_path):
+        """Test pipeline execution with configuration directory."""
+
+        os.chdir(tmp_path)
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "numbers.yaml").write_text("[1, 2, 3]")
+
+        composer = HamiltonComposer(
+            "tests.defs.pipelines.create_pipelines", config_path=config_dir
         )
         config = composer.load_config()
         pipelines = composer.find_pipelines(config)
@@ -57,18 +74,18 @@ class TestPipelineExecutionWithConfig:
         """Test execution with runtime config file override."""
         os.chdir(tmp_path)
 
-        config_file1 = tmp_path / "config1.yaml"
-        config_file1.write_text("numbers: [1, 2, 3]")
+        config_path1 = tmp_path / "config1.yaml"
+        config_path1.write_text("numbers: [1, 2, 3]")
 
-        config_file2 = tmp_path / "config2.yaml"
-        config_file2.write_text("numbers: [2, 3, 4]")
+        config_path2 = tmp_path / "config2.yaml"
+        config_path2.write_text("numbers: [2, 3, 4]")
 
         composer = HamiltonComposer(
-            "tests.defs.pipelines.create_pipelines", config_file=config_file1
+            "tests.defs.pipelines.create_pipelines", config_path=config_path1
         )
 
         # Override config at runtime
-        config = composer.load_config(filepath=config_file2)
+        config = composer.load_config(path=config_path2)
         pipelines = composer.find_pipelines(config)
         result = pipelines["simple_pipeline"].execute(inputs=config)
         assert result == {"sum_doubled": 18}  # 2*2 + 2*3 + 2*4 = 18
@@ -76,11 +93,11 @@ class TestPipelineExecutionWithConfig:
     def test_execution_with_schema_validation(self, tmp_path):
         """Test pipeline execution with schema validation."""
         os.chdir(tmp_path)
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("numbers: [2, 4, 6]")
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("numbers: [2, 4, 6]")
 
         composer = HamiltonComposer(
-            "tests.defs.pipelines.create_pipelines", config_file=config_file, schema=SimpleSchema
+            "tests.defs.pipelines.create_pipelines", config_path=config_path, schema=SimpleSchema
         )
         config = composer.load_config()
         pipelines = composer.find_pipelines(config)
@@ -90,11 +107,11 @@ class TestPipelineExecutionWithConfig:
     def test_execution_with_node_branching_config(self, tmp_path):
         """Test pipeline execution with node-specific branching."""
         os.chdir(tmp_path)
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("numbers: [1, 2, 3]\nmethod: add\nfactor: 2")
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("numbers: [1, 2, 3]\nmethod: add\nfactor: 2")
 
         composer = HamiltonComposer(
-            "tests.defs.pipelines.create_pipelines", config_file=config_file
+            "tests.defs.pipelines.create_pipelines", config_path=config_path
         )
         config = composer.load_config()
         pipelines = composer.find_pipelines(config)

--- a/tests/cli/test_cmd_run.py
+++ b/tests/cli/test_cmd_run.py
@@ -21,13 +21,13 @@ class TestRunPipelineWithNoConfig:
 class TestRunPipelineWithConfig:
     """Test running pipelines with configuration files."""
 
-    def test_run_with_config_file(self, runner):
+    def test_run_with_config_path(self, runner):
         """Test pipeline execution with YAML configuration file."""
         parameters_file = Path("parameters.yaml")
         parameters_file.write_text("numbers: [1, 2, 3]")
 
         composer = HamiltonComposer(
-            "tests.defs.pipelines.create_pipelines", config_file=parameters_file
+            "tests.defs.pipelines.create_pipelines", config_path=parameters_file
         )
         cli = build_cli("test-project", composer)
 
@@ -41,13 +41,29 @@ class TestRunPipelineWithConfig:
         parameters_file.write_text("numbers: [1, 2, 3]")
 
         composer = HamiltonComposer(
-            "tests.defs.pipelines.create_pipelines", config_file=parameters_file
+            "tests.defs.pipelines.create_pipelines", config_path=parameters_file
         )
         cli = build_cli("test-project", composer)
 
         result = runner.invoke(cli, ["run", "simple_pipeline", "numbers=[2,3,4]"])
         assert result.exit_code == 0
         assert "sum_doubled = 18" in result.output
+
+    def test_run_with_config_directory(self, runner):
+        """Test pipeline execution with a configuration directory."""
+
+        parameters_dir = Path("config")
+        parameters_dir.mkdir()
+        (parameters_dir / "numbers.yaml").write_text("[1, 2, 3]")
+
+        composer = HamiltonComposer(
+            "tests.defs.pipelines.create_pipelines", config_path=parameters_dir
+        )
+        cli = build_cli("test-project", composer)
+
+        result = runner.invoke(cli, ["run", "simple_pipeline"])
+        assert result.exit_code == 0
+        assert "sum_doubled = 12" in result.output
 
     def test_run_with_schema_validation(self, runner):
         """Test pipeline execution with schema validation."""
@@ -60,7 +76,7 @@ class TestRunPipelineWithConfig:
         parameters_file.write_text("numbers: [1, 2, 3]")
 
         composer = HamiltonComposer(
-            "tests.defs.pipelines.create_pipelines", config_file=parameters_file, schema=Config
+            "tests.defs.pipelines.create_pipelines", config_path=parameters_file, schema=Config
         )
         cli = build_cli("test-project", composer)
 

--- a/tests/cli/test_factory.py
+++ b/tests/cli/test_factory.py
@@ -60,8 +60,8 @@ class TestCLIFactory:
 
         runner = CliRunner()
         with runner.isolated_filesystem():
-            config_file = Path("config.yaml")
-            config_file.write_text("test: value")
+            config_path = Path("config.yaml")
+            config_path.write_text("test: value")
 
-            result = runner.invoke(cli, ["--config-file", str(config_file), "list"])
+            result = runner.invoke(cli, ["--config-path", str(config_path), "list"])
             assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- rename the HamiltonComposer configuration interface to `config_path`, keep a deprecated alias, and allow directory inputs when resolving config locations
- load configuration directories recursively while handling nested structures and scalar YAML files, and update the CLI context/option to pass along `--config-path`
- refresh documentation and tests to cover directory-based configs and the new CLI flag

## Testing
- `PYTHONPATH=src pytest tests/api/test_initialization.py tests/api/test_execution.py tests/cli/test_factory.py tests/cli/test_cmd_run.py -q`
- `PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: No module named 'IPython')*

------
https://chatgpt.com/codex/tasks/task_e_68c9734d344c8327a7195cf421e94010